### PR TITLE
Make compatible with older versions and other changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.mbukowiecki'
-version '2.0'
+version '2.1'
 
 repositories {
     mavenCentral()
@@ -21,16 +21,15 @@ intellij {
     version = '2022.1'
     type = 'IC'
     plugins = ['java']
+    updateSinceUntilBuild = false
 }
 
 patchPluginXml {
     changeNotes = project.file('change-notes.html').text
-    // https://plugins.jetbrains.com/docs/intellij/gradle-guide.html#patching-the-plugin-configuration-file
-    sinceBuild "202.6397.94"
 }
 
 runPluginVerifier {
-    ideVersions("IC-2022.1")
+    ideVersions = ["IC-2022.1"]
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,12 @@ intellij {
 
 patchPluginXml {
     changeNotes = project.file('change-notes.html').text
+    // https://plugins.jetbrains.com/docs/intellij/gradle-guide.html#patching-the-plugin-configuration-file
+    sinceBuild "202.6397.94"
+}
+
+runPluginVerifier {
+    ideVersions("IC-2022.1")
 }
 
 test {

--- a/src/main/java/com/mbukowiecki/evaluator/ThreadAccessEvaluator.kt
+++ b/src/main/java/com/mbukowiecki/evaluator/ThreadAccessEvaluator.kt
@@ -8,7 +8,7 @@ package com.mbukowiecki.evaluator
 import com.intellij.debugger.engine.JavaValue
 import com.intellij.icons.AllIcons
 import com.intellij.lang.java.JavaLanguage
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.xdebugger.evaluation.EvaluationMode
 import com.intellij.xdebugger.evaluation.XDebuggerEvaluator
 import com.intellij.xdebugger.frame.XValue
@@ -98,7 +98,7 @@ class ThreadAccessEvaluator {
     companion object {
 
         fun getInstance(): ThreadAccessEvaluator {
-            return ServiceManager.getService(ThreadAccessEvaluator::class.java)
+            return ApplicationManager.getApplication().getService(ThreadAccessEvaluator::class.java)
         }
     }
 }

--- a/src/main/java/com/mbukowiecki/ui/ThreadStatusModel.kt
+++ b/src/main/java/com/mbukowiecki/ui/ThreadStatusModel.kt
@@ -5,6 +5,7 @@
 
 package com.mbukowiecki.ui
 
+import com.intellij.ui.components.JBList
 import com.intellij.util.ui.JBFont
 import com.mbukowiecki.providers.CheckCallback
 import com.mbukowiecki.providers.PresentationWrapper
@@ -16,8 +17,8 @@ import javax.swing.JList
  */
 class ThreadStatusModel {
 
-    val firstList = JList<PresentationWrapper>(DefaultListModel())
-    val secondList = JList<PresentationWrapper>(DefaultListModel())
+    val firstList = JBList<PresentationWrapper>(DefaultListModel())
+    val secondList = JBList<PresentationWrapper>(DefaultListModel())
 
     init {
         firstList.font = JBFont.label()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,6 +2,8 @@
     <id>io.intellij-sdk-thread-access</id>
     <name>Thread Access Info</name>
     <vendor email="m.bukowiecki0407@gmail.com" url="https://github.com/marcin-bukowiecki">Marcin Bukowiecki</vendor>
+    
+    <idea-version since-build="202.6397.94"/>
 
     <description><![CDATA[
         Debugging plugins extended with Thread access information according to Intellij Platform SDK threading rules.


### PR DESCRIPTION
Hello! First of all, thanks for this nice plugin, it's really helpful.

I'd like you to consider merging these changes I made:
1. First of all and most importantly make the plugin compatible with older versions of IDEA by explicitly setting a sinceBuild. I've found the build number by running an code inspection and seeing what the lowest build was where all the APIs used in your code were available.
2. I've added an alternative way to check if the debugging session is for an IntelliJ Plugin. Instead of evaluating I search for the presence of the ApplicationManager class in the process classpath and if yes that means it's an IntelliJ instance. This is not just a little bit faster (actually, upto 30x faster in some cases) but, more importantly, also handles the case where Application.isInternal() returns false which is the default case for Legacy IntelliJ Plugin projects for example. I haven't deleted the original checking logic in case mine fails.
3. Some minor changes that IntelliJ itself suggeste: replacing deprecatedServiceManager. getService() with the new way of getting application services and replacing JList with JBList (doesn't break anything).

Thank you. Feel free to test these changes and tell me what you think about them.